### PR TITLE
Add DISCORD_TOKEN fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ A simple Discord music bot using `discord.py` and `yt-dlp`.
    ```
    Ensure `ffmpeg` is installed on your system for audio playback.
 3. Copy `config.json.example` to `config.json` and edit it to include your
-   Discord bot token:
+   Discord bot token. Alternatively set the token via the `DISCORD_TOKEN`
+   environment variable:
    ```bash
    cp config.json.example config.json
    # then edit config.json and set the "token" value
    ```
+   If `config.json` is missing or the `token` field is empty, `bot.py`
+   will use the value of `DISCORD_TOKEN` if it is set.
 4. Run the bot:
    ```bash
    python bot.py

--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@ import discord
 from discord.ext import commands
 import yt_dlp
 import json
+import os
 
 bot = commands.Bot(command_prefix="!")
 
@@ -86,14 +87,20 @@ async def skip(ctx):
         await ctx.send("Nothing is playing")
 
 if __name__ == "__main__":
+    token = None
     try:
         with open("config.json", "r") as f:
             config = json.load(f)
         token = config.get("token")
     except FileNotFoundError:
-        raise RuntimeError(
-            "config.json not found. Copy config.json.example and add your Discord token."
-        )
+        pass
+
     if not token:
-        raise RuntimeError("Discord token not provided in config.json")
+        token = os.environ.get("DISCORD_TOKEN")
+
+    if not token:
+        raise RuntimeError(
+            "Discord token not provided. Set it in config.json or the DISCORD_TOKEN environment variable."
+        )
+
     bot.run(token)


### PR DESCRIPTION
## Summary
- allow reading token from `DISCORD_TOKEN` env var when `config.json` is missing or empty
- document environment variable option in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684855a9f9e48325a6e6ddd2a2ec2426