### PR TITLE
Update AMP docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ Tracks are queued and played in order.
 If you are using CubeCoders AMP, the repository includes `amp_module.py` which
 registers the bot as a managed server. AMP will load this file automatically and
 start `bot.py` as a Python application.
+
+When AMP launches the bot it expects `config.json` to be in its working directory (usually alongside `bot.py` and `amp_module.py`). If the file is missing, the bot will not start. Check AMP's logs for an error about the missing config if this happens.
+


### PR DESCRIPTION
## Summary
- clarify where AMP looks for `config.json`
- mention checking AMP logs if the bot does not start

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684855a968f08325afa1e106e456f7cc